### PR TITLE
fixed the empty and full drawables not being drawn correctly on APIs prior to 21

### DIFF
--- a/passcodeviewlib/src/main/java/in/arjsna/passcodeview/PassCodeView.java
+++ b/passcodeviewlib/src/main/java/in/arjsna/passcodeview/PassCodeView.java
@@ -326,10 +326,14 @@ public class PassCodeView extends View {
      */
     private void setFilledCount(int count) {
         filledCount = count > digits ? digits : count;
-        invalidate(drawableStartX,
+        /*invalidate(drawableStartX,
                 drawableStartX,
                 drawableStartX + getMeasuredWidth(),
-                drawableStartY + getMeasuredHeight());
+                drawableStartY + getMeasuredHeight());*/
+        /* The coordinates passed to `invalidate` method above is wrong
+        		which makes the View not be drawn correctly
+        		hence calling the default invalidate method */
+        invalidate();
     }
 
     @Override


### PR DESCRIPTION
Addressing this issue https://github.com/Arjun-sna/android-passcodeview/issues/6